### PR TITLE
[WIP] support no consumer groups in KafkaEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,63 @@ config :kafka_consumer,
 
 * Start your app.
 
+### No Consumer Group support
+
+If your Kafka setup does not support does not support consumer groups, then it is possible to still use KafkaConsumer. To still use KafkaConsumer you must
+
+* Set `offset_server` to a module that `use`'s `KafkaConsumer.OffsetServer`
+
+```elixir
+# config.exs
+
+config :kafka_ex,
+  brokers: [{"localhost", 9092}],
+  consumer_group: :no_consumer_group,
+  sync_timeout: 3000,
+  max_restarts: 10,
+  max_seconds: 60
+
+
+config :kafka_consumer,
+  default_pool_size: 5,
+  default_pool_max_overflow: 10,
+  offset_server: YourModule.OffsetServer
+  event_handlers: [
+    {KafkaConsumer.TestEventHandler, [{"topic", 0}, {"topic2", 0}], size: 5, max_overflow: 5}
+  ]
+
+# offset_server.ex
+
+defmodule YourModule.OffsetServer do
+  use KafkaConsumer.OffsetServer
+end
+```
+
+KafkaConsumer will then query this server for the current offset when appropriate.
+
+#### Starting the OffsetServer
+
+The OffsetServer is a `GenServer` and **must be started by you, and supervised by you**.
+
+It is started by calling `start_link/1`. You must provide the topic when starting the server, as the server will be named after your topic
+
+```elixir
+#starts a GenServer with a name of :that_one_topic
+YouModule.OffsetServer.start_link("that.one.topic")
+```
+
+#### Incrementing, Decrementing and Getting the offset
+
+Upon startup, KafkaConsumer will get get the **latest offset** from `KafkaEx`. After that, you must increment or decrement the offset yourself. This can be done through the `increment/1` and `decrement/1` functions. They both take the topic as the first parameter.
+
+```elixir
+YourModule.OffsetServer.increment("that.one.topic") # :ok
+YourModule.OffsetServer.decrement("that.one.topic") # :ok
+YourModule.OffsetServer.get("that.one.topic") # offset
+```
+
+please see the the offset server [behaviour](lib/kafka_consumer/offset_server.ex) for more details on what it does and does not support.
+
 ## Configuration
 
 `event_handlers` key in configuration accepts list of tuples `{handler_module, topics, opts}`, where you can omit options parameter and worker use default values (acceptable for pool size and max_overflow).

--- a/lib/kafka_consumer/offset_server.ex
+++ b/lib/kafka_consumer/offset_server.ex
@@ -1,0 +1,141 @@
+defmodule KafkaConsumer.OffsetServer do
+  @type offset :: number
+  @type noreply :: {:noreply, offset}
+  @type reply :: {:reply, offset, offset}
+  @type topic :: String.t
+
+  @callback increment(topic) :: noreply
+  @callback decrement(topic) :: noreply
+  @callback get(topic) :: reply
+  @callback save(topic) :: reply
+  @callback start_link(topic) :: {:ok, pid}
+
+
+  defmacro __using__(_) do
+    quote do
+      @type offset :: number
+      @type noreply :: {:noreply, offset}
+      @type reply :: {:reply, offset, offset}
+      @type topic :: String.t
+
+      @moduledoc """
+      Holds the last processed offset
+      All servers are registerd with an atom of the topic
+
+      `start_link("that.one.topic")` will register a server under `:that_one_topic`
+      """
+      use GenServer
+
+      @behaviour KafkaConsumer.OffsetServer
+
+      def start_link(topic) do
+        name = make_server_name(topic)
+        GenServer.start_link(
+          __MODULE__,
+          get_latest_offset(topic),
+          name: name,
+          id: name
+        )
+      end
+
+      @doc """
+      increments the offset
+      """
+      @spec increment(topic) :: noreply
+      def increment(topic) do
+        GenServer.cast(make_server_name(topic), :increment)
+      end
+
+      @doc """
+      decrements the offset
+      """
+      @spec decrement(topic) :: noreply
+      def decrement(topic) do
+        GenServer.cast(make_server_name(topic), :decrement)
+      end
+
+      @doc """
+      saves the offset
+      """
+      @spec increment(topic) :: noreply
+      def save(topic) do
+        GenServer.cast(make_server_name(topic), :save)
+      end
+
+      @doc """
+      gets the offset
+      """
+      @spec get(topic) :: reply
+      def get(topic) do
+        GenServer.call(make_server_name(topic), :get)
+      end
+
+      @doc """
+      handles the increment of the offset
+      """
+      @spec handle_cast(atom, offset) :: noreply
+      def handle_cast(:increment, offset) do
+        {:noreply, offset + 1}
+      end
+
+      @doc """
+      handles the decrement of the offset
+      """
+      @spec handle_cast(:decrement, offset) :: noreply
+      def handle_cast(:decrement, offset) do
+        {:noreply, offset - 1}
+      end
+      @doc """
+      handles the saving of the offset
+      """
+      @spec handle_cast(:save, offset) :: noreply
+      def handle_cast(:save, offset) do
+        {:noreply, offset}
+      end
+
+      @doc """
+      handles the getting of the offset
+      """
+      @spec handle_call(:get, any, offset) :: reply
+      def handle_call(:get, _, offset) do
+        {:reply, offset, offset}
+      end
+
+      @doc """
+      makes the server name from a topic
+      """
+      @spec make_server_name(topic) :: atom
+      def make_server_name(topic) do
+        String.to_atom(String.replace(topic, ".", "_"))
+      end
+
+      @doc """
+      gets the offset from the kafka topic.
+      Defaults to the latest_offset
+      """
+      @spec get_latest_offset(topic) :: offset
+      def get_latest_offset(topic) do
+        response = KafkaEx.latest_offset(topic, 0)
+
+        response
+          |> Enum.at(0)
+          |> Map.get(:partition_offsets)
+          |> Enum.at(0)
+          |> Map.get(:offset)
+          |> Enum.at(0)
+      end
+
+      defoverridable [
+        start_link: 1,
+        handle_cast: 2,
+        handle_call: 3,
+        get: 1,
+        save: 1,
+        decrement: 1,
+        increment: 1,
+        make_server_name: 1,
+        get_latest_offset: 1
+      ]
+    end
+  end
+end

--- a/lib/kafka_consumer/offset_server.ex
+++ b/lib/kafka_consumer/offset_server.ex
@@ -101,13 +101,6 @@ defmodule KafkaConsumer.OffsetServer do
         {:reply, offset, offset}
       end
 
-      @doc """
-      makes the server name from a topic
-      """
-      @spec make_server_name(topic) :: atom
-      def make_server_name(topic) do
-        String.to_atom(String.replace(topic, ".", "_"))
-      end
 
       @doc """
       gets the offset from the kafka topic.
@@ -123,6 +116,14 @@ defmodule KafkaConsumer.OffsetServer do
           |> Enum.at(0)
           |> Map.get(:offset)
           |> Enum.at(0)
+      end
+
+      @doc """
+      makes the server name from a topic
+      """
+      @spec make_server_name(topic) :: atom
+      defp make_server_name(topic) do
+        String.to_atom(String.replace(topic, ".", "_"))
       end
 
       defoverridable [

--- a/lib/kafka_consumer/offset_server.ex
+++ b/lib/kafka_consumer/offset_server.ex
@@ -28,6 +28,10 @@ defmodule KafkaConsumer.OffsetServer do
 
       @behaviour KafkaConsumer.OffsetServer
 
+      @doc """
+      Starts a OffsetServer for the given topic
+      """
+      @spec start_link(topic) :: {:ok, pid}
       def start_link(topic) do
         name = make_server_name(topic)
         GenServer.start_link(

--- a/lib/kafka_consumer/utils.ex
+++ b/lib/kafka_consumer/utils.ex
@@ -69,6 +69,10 @@ defmodule KafkaConsumer.Utils do
     [topic, partition] |> Enum.join("$") |> String.to_atom
   end
 
+  def has_consumer_group? do
+    Application.get_env(:kafka_ex, :consumer_group) != :no_consumer_group
+  end
+
   # defp event_handler_spec({topic, partition, handler, handler_pool, size, max_overflow}) do
   defp event_handler_spec({handler, topics, opts}) do
     size = Keyword.get(opts, :size, default_pool_size())
@@ -108,5 +112,9 @@ defmodule KafkaConsumer.Utils do
 
   defp default_pool_max_overflow do
     Application.get_env(:kafka_consumer, :default_pool_max_overflow)
+  end
+
+  def offset_server do
+    Application.get_env(:kafka_consumer, :offset_server)
   end
 end

--- a/test/offset_server_test.ex
+++ b/test/offset_server_test.ex
@@ -1,0 +1,56 @@
+defmodule KafkaConsumer.OffsetServerTest do
+  use ExUnit.Case, async: false
+  import Mock
+
+  @the_topic_string "the.topic"
+  @the_topic_atom :the_topic
+
+  def mock_lastest_offset do
+    fn(_topic, _partition) -> [%{partition_offsets: [%{offset: [0]}]}] end
+  end
+
+  describe "when start_link/1 is called with a string" do
+    test "it starts a GenServer" do
+      with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
+        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+
+        assert pid
+      end
+    end
+
+    test "it registers the GenServer under the topic" do
+      with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
+        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+
+        assert Process.whereis(@the_topic_atom) == pid
+      end
+    end
+  end
+
+  describe "behaviour" do
+    setup do
+      with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
+        KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+      end
+
+      {:ok, []}
+    end
+
+
+    test "it increments the offset" do
+      KafkaConsumer.TestOffsetServer.increment(@the_topic_string)
+
+      assert KafkaConsumer.TestOffsetServer.get(@the_topic_string) == 1
+    end
+
+    test "it decrements the offset" do
+      KafkaConsumer.TestOffsetServer.decrement(@the_topic_string)
+
+      assert KafkaConsumer.TestOffsetServer.get(@the_topic_string) == -1
+    end
+
+    test "it gets the offset" do
+      assert KafkaConsumer.TestOffsetServer.get(@the_topic_string)
+    end
+  end
+end

--- a/test/offset_server_test.ex
+++ b/test/offset_server_test.ex
@@ -4,6 +4,7 @@ defmodule KafkaConsumer.OffsetServerTest do
 
   @the_topic_string "the.topic"
   @the_topic_atom :the_topic
+  @partition 0
 
   def mock_lastest_offset do
     fn(_topic, _partition) -> [%{partition_offsets: [%{offset: [0]}]}] end
@@ -12,7 +13,7 @@ defmodule KafkaConsumer.OffsetServerTest do
   describe "when start_link/1 is called with a string" do
     test "it starts a GenServer" do
       with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
-        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string, @partition)
 
         assert pid
       end
@@ -20,7 +21,7 @@ defmodule KafkaConsumer.OffsetServerTest do
 
     test "it registers the GenServer under the topic" do
       with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
-        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+        {:ok, pid} = KafkaConsumer.TestOffsetServer.start_link(@the_topic_string, @partition)
 
         assert Process.whereis(@the_topic_atom) == pid
       end
@@ -30,7 +31,7 @@ defmodule KafkaConsumer.OffsetServerTest do
   describe "behaviour" do
     setup do
       with_mock KafkaEx, [latest_offset: mock_lastest_offset] do
-        KafkaConsumer.TestOffsetServer.start_link(@the_topic_string)
+        KafkaConsumer.TestOffsetServer.start_link(@the_topic_string, @partition)
       end
 
       {:ok, []}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,4 +36,8 @@ defmodule KafkaConsumer.TestEventHandler do
   end
 end
 
+defmodule KafkaConsumer.TestOffsetServer do
+  use KafkaConsumer.OffsetServer
+end
+
 Application.ensure_all_started(:kafka_consumer)


### PR DESCRIPTION
I noticed that Kafka-Consumer makes the assumption that consumer groups are being used. However, the particular kafka setup i have to interact with does not support consumer groups. 
1. I've added a function that 
   - checks the `kafkaex` configuration for it's `consumer_group`
   - if the consumer group is `:no_consumer_group`
     - adds a `:auto_commit false` to the options list
   - if the consumer group is not `:no_consumer_group`
     - returns an options list containing `worker_name: worker_name`
2. refactors the streaming portion of `consume` as i found it a bit squished / hard to read
   - very happy to remove this portion of the PR if you think it's not needed
